### PR TITLE
Use the W dateformat mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Macros can also execute any of your snippets which is super neat. Just insert th
         "directory": "Weekly",
         "extension": ".md",
         "name": "weekly-note",
-        "date": "yyyy-mm-dd"
+        "date": "yyyy-W"
       }
     ],
     "doMySnippet": [

--- a/settings.json
+++ b/settings.json
@@ -15,7 +15,7 @@
         "directory": "Weekly",
         "extension": ".md",
         "name": "weekly-note",
-        "date": "yyyy-mm-dd"
+        "date": "yyyy-W"
       }
     ],
     "monthlyNote": [


### PR DESCRIPTION
Use the W dateformat mask that returns ISO 8601 week number of the year (1-53) to make the weekly file name
be stable throughout the week.

Output for `yyyy-W` for this week would be `2020-34`.